### PR TITLE
fix: ESP32 log cleanup never deletes any file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3332,26 +3332,37 @@ bool delete_log_oldest() {
 #elif defined(ESP32)
 bool delete_log_oldest() {
 	File dir = LittleFS.open(LOG_PREFIX);
-	time_os_t oldest_t = ULONG_MAX;
-	File oldest;
-	if (!dir.isDirectory()) {
-		DEBUG_PRINTLN(F("delete_log_oldest: not a directory"));
+	if (!dir) {
+		DEBUG_PRINTLN(F("delete_log_oldest: cannot open log folder"));
 		return false;
 	}
+	if (!dir.isDirectory()) {
+		DEBUG_PRINTLN(F("delete_log_oldest: not a directory"));
+		dir.close();
+		return false;
+	}
+	// remember the file NAME, not the File handle: the handle is invalidated
+	// by the next openNextFile() call
+	time_os_t oldest_t = ULONG_MAX;
+	String oldest_fn;
 	File file = dir.openNextFile();
 	while (file) {
 		time_os_t t = file.getLastWrite();
 		if(t<oldest_t) {
 			oldest_t = t;
-			oldest = file;
+			oldest_fn = file.name();
 		}
+		file.close();
 		file = dir.openNextFile();
 	}
-	if(oldest.available()) {
+	dir.close();
+	if(oldest_fn.length()>0) {
+		// depending on the arduino-esp32 core version, name() returns either the
+		// bare file name or the full path
+		String path = (oldest_fn[0]=='/') ? oldest_fn : String(LOG_PREFIX) + oldest_fn;
 		DEBUG_PRINT(F("deleting "))
-		DEBUG_PRINTLN(oldest.name());
-		LittleFS.remove(dir.name() + String("/") + oldest.name());
-		return true;
+		DEBUG_PRINTLN(path);
+		return LittleFS.remove(path);
 	} else {
 		return false;
 	}


### PR DESCRIPTION
## Problem

`delete_log_oldest()` never deletes anything on ESP32. Two independent bugs:

1. **Invalidated file handle** (`main.cpp:3346`) — the oldest entry is stored as a `File` object, but that handle is invalidated by the next `dir.openNextFile()` call. By the end of the loop it points to nothing.
2. **Wrong validity check** (`main.cpp:3350`) — `oldest.available()` returns 0 for an empty file, so empty log files are never removed.

The ESP8266 branch directly above (`main.cpp:3312-3331`) does it correctly by remembering the file *name* instead of the handle.

## Impact

The automatic log cleanup (`main.cpp:3113/3117/3193/3199`) silently does nothing on ESP32. Log files accumulate until LittleFS is full. Once full, all config writes fail — station names, programs, options — and OTA updates can no longer download.

Observed on a 2 MB LittleFS: 2,064,384 of 2,072,576 bytes used (99.6%), only 8192 bytes free (exactly `MIN_DISK_FREE`). Clearing `/logs/` via `/dl?day=all` freed 1.98 MB.

## Fix

Mirror the ESP8266 approach: remember the file name, validate via string length. Also handle both `name()` conventions (bare name vs. full path, depending on the arduino-esp32 core version), close all handles, and return the actual result of `LittleFS.remove()` instead of unconditional `true`.

## Testing

Not compiled — the change sits entirely inside an `#elif defined(ESP32)` block and no ESP32 toolchain was available. Needs a hardware test: populate `/logs/` with several files including an empty one, trigger cleanup, verify the oldest file is removed.
