### PR TITLE
fix: propagate storage write failures instead of reporting success

### DIFF
--- a/OpenSprinkler.cpp
+++ b/OpenSprinkler.cpp
@@ -2512,15 +2512,19 @@ void OpenSprinkler::get_station_name(unsigned char sid, char tmp[]) {
 	file_read_block(STATIONS_FILENAME, tmp, (uint32_t)sid*sizeof(StationData)+offsetof(StationData, name), STATION_NAME_SIZE);
 }
 
-/** Set station name */
-void OpenSprinkler::set_station_name(unsigned char sid, char tmp[]) {
+/** Set station name
+ * Returns true if the name is stored (or already up to date), false on error
+ */
+bool OpenSprinkler::set_station_name(unsigned char sid, char tmp[]) {
+	if(sid>=nstations) return false;
 	tmp[STATION_NAME_SIZE]=0;
 	char n0[STATION_NAME_SIZE+1];
-	get_station_name(sid, n0);
+	n0[STATION_NAME_SIZE]=0;
+	if(file_read_block(STATIONS_FILENAME, n0, (uint32_t)sid*sizeof(StationData)+offsetof(StationData, name), STATION_NAME_SIZE)!=STATION_NAME_SIZE)
+		return false;
 	size_t len = strlen(n0);
-	if(len!=strlen(tmp) || memcmp(n0, tmp, len)!=0) { // only write if the name has changed
-		file_write_block(STATIONS_FILENAME, tmp, (uint32_t)sid*sizeof(StationData)+offsetof(StationData, name), STATION_NAME_SIZE);
-	}
+	if(len==strlen(tmp) && memcmp(n0, tmp, len)==0) return true; // name unchanged, nothing to write
+	return file_write_block(STATIONS_FILENAME, tmp, (uint32_t)sid*sizeof(StationData)+offsetof(StationData, name), STATION_NAME_SIZE);
 }
 
 /** Get station type */

--- a/OpenSprinkler.h
+++ b/OpenSprinkler.h
@@ -455,7 +455,7 @@ static unsigned char iopts[]; // integer options (initialized — must NOT be in
 	static void get_station_data(unsigned char sid, StationData* data); // get station data
 	static void set_station_data(unsigned char sid, StationData* data); // set station data
 	static void get_station_name(unsigned char sid, char buf[]); // get station name
-	static void set_station_name(unsigned char sid, char buf[]); // set station name
+	static bool set_station_name(unsigned char sid, char buf[]); // set station name, false if it could not be stored
 	static unsigned char get_station_type(unsigned char sid); // get station type
 	static unsigned char is_sequential_station(unsigned char sid);
 	static uint16_t get_flow_pulse_rate_100();

--- a/opensprinkler_server.cpp
+++ b/opensprinkler_server.cpp
@@ -864,7 +864,10 @@ void server_change_stations(OTF_PARAMS_DEF) {
 			urlDecode(tmp_buffer);
 			#endif
 			strReplaceQuoteBackslash(tmp_buffer);
-			os.set_station_name(sid, tmp_buffer);
+			if(!os.set_station_name(sid, tmp_buffer)) {
+				// the name could not be persisted (e.g. file system full)
+				handle_return(HTML_NOT_ENOUGH_SPACE);
+			}
 		}
 	}
 

--- a/utils.cpp
+++ b/utils.cpp
@@ -492,25 +492,58 @@ ulong file_read_block(const char *fn, void *dst, ulong pos, ulong len) {
 	return result;
 }
 
-void file_write_block(const char *fn, const void *src, ulong pos, ulong len) {
+bool file_write_block(const char *fn, const void *src, ulong pos, ulong len) {
 #if defined(ESP8266) || defined(ESP32)
 	File f = LittleFS.open(fn, "r+");
-	if(!f) f = LittleFS.open(fn, "w");
-	if(f) {
-		f.seek(pos, SeekSet);
-		f.write((unsigned char*)src, len);
-		f.close();
+	if(!f) {
+		// only create a new file: "w" truncates, which would destroy an existing
+		// structured binary file if it merely failed to open for another reason
+		if(LittleFS.exists(fn)) {
+			DEBUG_PRINTF("file_write_block: cannot open %s for update\n", fn);
+			return false;
+		}
+		f = LittleFS.open(fn, "w");
 	}
+	if(!f) {
+		DEBUG_PRINTF("file_write_block: cannot create %s\n", fn);
+		return false;
+	}
+	if(!f.seek(pos, SeekSet)) {
+		DEBUG_PRINTF("file_write_block: seek failed on %s at %lu\n", fn, (unsigned long)pos);
+		f.close();
+		return false;
+	}
+	size_t written = f.write((const unsigned char*)src, len);
+	f.close();
+	if(written != (size_t)len) {
+		DEBUG_PRINTF("file_write_block: short write on %s at %lu: expected %lu, wrote %lu\n",
+			fn, (unsigned long)pos, (unsigned long)len, (unsigned long)written);
+		return false;
+	}
+	return true;
 
 #elif defined(ARDUINO)
 
 	sd.chdir("/");
 	SdFile file;
 	int ret = file.open(fn, O_CREAT | O_RDWR);
-	if(!ret) return;
-	file.seekSet(pos);
-	file.write(src, len);
+	if(!ret) {
+		DEBUG_PRINTF("file_write_block: cannot open %s\n", fn);
+		return false;
+	}
+	if(!file.seekSet(pos)) {
+		DEBUG_PRINTF("file_write_block: seek failed on %s at %lu\n", fn, (unsigned long)pos);
+		file.close();
+		return false;
+	}
+	int written = file.write(src, len);
 	file.close();
+	if(written < 0 || (ulong)written != len) {
+		DEBUG_PRINTF("file_write_block: short write on %s at %lu: expected %lu, wrote %d\n",
+			fn, (unsigned long)pos, (unsigned long)len, written);
+		return false;
+	}
+	return true;
 
 #else
 
@@ -518,11 +551,23 @@ void file_write_block(const char *fn, const void *src, ulong pos, ulong len) {
 	if(!fp) {
 		fp = fopen(get_filename_fullpath(fn), "wb+");
 	}
-	if(fp) {
-		fseek(fp, pos, SEEK_SET); //this fails silently without the above change
-		fwrite(src, 1, len, fp);
-		fclose(fp);
+	if(!fp) {
+		DEBUG_PRINTF("file_write_block: cannot open %s\n", fn);
+		return false;
 	}
+	if(fseek(fp, pos, SEEK_SET)) { //this fails silently without the above change
+		DEBUG_PRINTF("file_write_block: seek failed on %s at %lu\n", fn, (unsigned long)pos);
+		fclose(fp);
+		return false;
+	}
+	size_t written = fwrite(src, 1, len, fp);
+	bool ok = (fclose(fp) == 0);
+	if(written != (size_t)len || !ok) {
+		DEBUG_PRINTF("file_write_block: short write on %s at %lu: expected %lu, wrote %lu\n",
+			fn, (unsigned long)pos, (unsigned long)len, (unsigned long)written);
+		return false;
+	}
+	return true;
 
 #endif
 

--- a/utils.h
+++ b/utils.h
@@ -75,7 +75,7 @@ bool file_exists(const char *fname);
 ulong file_size(const char *fn);
 
 ulong file_read_block (const char *fname, void *dst, ulong pos, ulong len);
-void file_write_block(const char *fname, const void *src, ulong pos, ulong len);
+bool file_write_block(const char *fname, const void *src, ulong pos, ulong len); // returns true only on a fully successful write
 void file_append_block(const char *fname, const void *src, ulong len);
 void file_copy_block (const char *fname, ulong from, ulong to, ulong len, void *tmp=0);
 unsigned char file_read_byte (const char *fname, ulong pos);


### PR DESCRIPTION
## Problem

Failed writes to persistent storage are silently swallowed and reported as success:

- `file_write_block()` (`utils.cpp:495`) is `void` and checks neither `open()`, `seek()`, nor the byte count returned by `write()`
- `set_station_name()` (`OpenSprinkler.cpp:2516`) is `void` and cannot report anything
- `/cs` (`opensprinkler_server.cpp:867`) ignores the result and unconditionally returns `HTML_SUCCESS` (`:932`)

## Evidence

Same controller, same request, same response — opposite outcome:

| Free space | `/cs?s0=...` response | Name stored? |
|---|---|---|
| 8,192 B (99.6% full) | `{"result":1,"item":""}` | **no** |
| 1,982,464 B (4.3% full) | `{"result":1,"item":""}` | yes |

Verified against both `/ja` and `/jn` (both read through `get_station_name()`), re-checked after 8 seconds, with browser and service-worker caching ruled out.

`result:1` currently means "the handler ran to completion", not "the value was stored". Any UI built on this API will confirm changes that never happened.

## Additional issue fixed

The `"w"` fallback in `file_write_block()` was unconditional. If `"r+"` failed on an *existing* file for any reason other than absence, `"w"` would truncate it — a structured binary file like `stns.dat` would be wiped and only the single block at `pos` rewritten. The fallback is now gated on `!LittleFS.exists(fn)`.

## Scope

Deliberately limited to the station-name path to keep the diff reviewable. `attribs_save()`, options and program writes have the same problem and are left for a follow-up PR. `file_append_block()` shares all three bugs.

## Compatibility

- On-disk binary format unchanged — no migration needed
- All 27 `file_write_block()` callers ignore the return value; `void`→`bool` is source-compatible (no `[[nodiscard]]` added, intentionally)
- `set_station_name()` has exactly one caller, updated
- Linux/OSPi branch verified with `g++ -fsyntax-only`, both with and without `-DENABLE_DEBUG`, plus `-Wformat`
- ESP32/ESP8266 branches not compiled (no toolchain available)
