### PR TITLE
fix: sensor log rotation compares record count against a byte limit

### DIFF
--- a/sensors.cpp
+++ b/sensors.cpp
@@ -1315,7 +1315,7 @@ void checkLogSwitch(uint8_t log) {
 
 void checkLogSwitchAfterWrite(uint8_t log) {
   ulong size = file_size(getlogfile(log));
-  if ((size / SENSORLOG_STORE_SIZE) >= MAX_LOG_SIZE) {  // switch logs if max reached
+  if (size >= MAX_LOG_SIZE) {  // switch logs if max reached (MAX_LOG_SIZE is a byte limit)
     if (logFileSwitch[log] == 1)
       logFileSwitch[log] = 2;
     else


### PR DESCRIPTION
## Problem

`checkLogSwitchAfterWrite()` (`sensors.cpp:1318`):

```cpp
ulong size = file_size(getlogfile(log));            // bytes
if ((size / SENSORLOG_STORE_SIZE) >= MAX_LOG_SIZE)  // records vs. byte limit
```

`MAX_LOG_SIZE` is documented as a byte limit (`sensors.h:96`: `2097152 // 2MB max`), but is compared against a record count. With `SensorLog_t` at 24 bytes, the effective threshold becomes ~48 MB — unreachable on a 2 MB LittleFS. Rotation never triggers.

## Fix

Compare bytes against bytes.

## Note

`MAX_LOG_SIZE` has exactly three occurrences repo-wide (two definitions, this one use); no other code interprets it as a record count. The non-ESP32 value of 8000 (`sensors.h:98`) yields ~333 records per file, which is conservative but consistent — raising it is a tuning decision for a separate PR.
